### PR TITLE
Update EIP-5792: Require atomic batching by default & update capabilities specifications

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -47,19 +47,19 @@ This object allows the applications to attach a capability-specific metadata to 
 
 The wallet:
 
-- MUST send the calls in the order specified in the request
-- MUST send the calls on the same chain identified by the request's `chainId` property
-- MUST NOT await for any calls to be finalized to complete the batch
-- MUST submit multiple calls as part of a single transaction, unless instructions for sequential execution are provided via a `capability`.
-  - Note that such a `capability` is not in the scope of this EIP and should be defined in its own ERC.
-- MUST NOT send any calls from the request if the user rejects the request
-- MAY revert all calls if any call fails
-- MAY send all calls as part of one or more transactions, depending on wallet capability
-- SHOULD stop executing the calls if any call fails
-- MAY reject the request if the from address does not match the enabled account
-- MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
-- MUST reject the request if it contains a `capability` (either top-level or call-level) that is not supported by the wallet and the `capability` is not explicitly marked as optional.
-  - Capabilities (both top-level and call-level) MUST be marked as optional by applications sending requests to wallets by passing an `optional` parameter set to `true` for each `capability` that is not required.
+* MUST send the calls in the order specified in the request
+* MUST send the calls on the same chain identified by the request's `chainId` property
+* MUST NOT await for any calls to be finalized to complete the batch
+* MUST submit multiple calls as part of a single transaction, unless instructions for sequential execution are provided via a `capability`.
+  * Note that such a `capability` is not in the scope of this EIP and should be defined in its own ERC.
+* MUST NOT send any calls from the request if the user rejects the request
+* MAY revert all calls if any call fails
+* MAY send all calls as part of one or more transactions, depending on wallet capability
+* SHOULD stop executing the calls if any call fails
+* MAY reject the request if the from address does not match the enabled account
+* MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
+* MUST reject the request if it contains a `capability` (either top-level or call-level) that is not supported by the wallet and the `capability` is not explicitly marked as optional.
+  * Capabilities (both top-level and call-level) MUST be marked as optional by applications sending requests to wallets by passing an `optional` parameter set to `true` for each `capability` that is not required.
 
 #### `wallet_sendCalls` RPC Specification
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -130,10 +130,10 @@ Note that the `receipts` objects of this method's response is a strict subset of
 
 The `capabilitiesResultsData` object allows the wallets to attach a capability-specific metadata to the response.
 
-- The receipts in the `receipts` field MUST be in order they are included on-chain.
-- The `receipts` field MUST contain receipts for all calls in a batch that were included on-chain, including reverted ones.
-- If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsStatus` MUST return a single receipt, corresponding to the transaction in which the calls were included.
-- The `logs` in the receipt objects MUST only include logs relevant to the calls submitted using `wallet_sendCalls`. For example, in the case of a transaction submitted onchain by an [ERC-4337](./eip-4337.md) bundler, the logs must only include those relevant to the user operation constructed using the calls submitted via `wallet_sendCalls`. I.e. the logs should not include those from other unrelated user operations submitted in the same bundle.
+* The receipts in the `receipts` field MUST be in order they are included on-chain.
+* The `receipts` field MUST contain receipts for all calls in a batch that were included on-chain, including reverted ones.
+* If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsStatus` MUST return a single receipt, corresponding to the transaction in which the calls were included.
+* The `logs` in the receipt objects MUST only include logs relevant to the calls submitted using `wallet_sendCalls`. For example, in the case of a transaction submitted onchain by an [ERC-4337](./eip-4337.md) bundler, the logs must only include those relevant to the user operation constructed using the calls submitted via `wallet_sendCalls`. I.e. the logs should not include those from other unrelated user operations submitted in the same bundle.
 
 #### `wallet_getCallsStatus` RPC Specification
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -20,7 +20,7 @@ Applications can specify that these onchain calls be executed taking advantage o
 
 The current methods used to send transactions from the user wallet and check their status are `eth_sendTransaction` and `eth_getTransactionReceipt`.
 
-The current methods used to send transactions from the user wallet and check their status do not meet modern developer demands and cannot accommodate new transaction formats. Even the name–- `eth_sendTransaction`-– is an artifact of a time when nodes served as wallets. 
+The current methods used to send transactions from the user wallet and check their status do not meet modern developer demands and cannot accommodate new transaction formats. Even the name–- `eth_sendTransaction`-– is an artifact of a time when nodes served as wallets.
 
 Today, developers want to send multiple calls batched together in a single RPC call, which many smart accounts can, in turn, execute atomically in a single transaction. Developers also want to make use of features afforded by new transaction formats, like paymasters in [ERC-4337](./eip-4337.md) transactions. `eth_sendTransaction` offers no way to do these things.
 
@@ -47,16 +47,17 @@ This object allows the applications to attach a capability-specific metadata to 
 
 The wallet:
 
-* MUST send the calls in the order specified in the request
-* MUST send the calls on the same chain identified by the request's `chainId` property
-* MUST NOT await for any calls to be finalized to complete the batch
-* MUST NOT send any calls from the request if the user rejects the request
-* MAY revert all calls if any call fails
-* MAY send all calls as part of one or more transactions, depending on wallet capability
-* SHOULD stop executing the calls if any call fails
-* MAY reject the request if the from address does not match the enabled account
-* MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
-* MUST reject the request if it contains a `capability` that is not supported by the wallet
+- MUST send the calls in the order specified in the request
+- MUST send the calls on the same chain identified by the request's `chainId` property
+- MUST NOT await for any calls to be finalized to complete the batch
+- MUST NOT send any calls from the request if the user rejects the request
+- MAY revert all calls if any call fails
+- MAY send all calls as part of one or more transactions, depending on wallet capability
+- SHOULD stop executing the calls if any call fails
+- MAY reject the request if the from address does not match the enabled account
+- MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
+- MUST reject the request if it contains a `capability` that is not supported by the wallet and the `capability` is not explicitly marked as optional.
+  - Capabilities MUST be marked as optional by applications sending requests to wallets by passing an `optional` parameter set to `true` for each `capability` that is not required.
 
 #### `wallet_sendCalls` RPC Specification
 
@@ -98,14 +99,16 @@ type SendCallsResult = string;
       }
     ],
     "capabilities": {
-      // Illustrative
       "paymasterService": {
-        "url": "https://..."
+        "url": "https://...",
+        "optional": true
       }
     }
   }
 ]
 ```
+
+Note that since the `paymasterService` `capability` is marked as optional, wallets that do not support it can still process and handle the request to the best of their ability. If this `optional` field were set to `false` or absent from the request, wallets that do not support the `capability` MUST reject the request.
 
 ##### `wallet_sendCalls` Example Return Value
 
@@ -125,10 +128,10 @@ Note that the `receipts` objects of this method's response is a strict subset of
 
 The `capabilitiesResultsData` object allows the wallets to attach a capability-specific metadata to the response.
 
-* The receipts in the `receipts` field MUST be in order they are included on-chain.
-* The `receipts` field MUST contain receipts for all calls in a batch that were included on-chain, including reverted ones.
-* If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsStatus` MUST return a single receipt, corresponding to the transaction in which the calls were included.
-* The `logs` in the receipt objects MUST only include logs relevant to the calls submitted using `wallet_sendCalls`. For example, in the case of a transaction submitted onchain by an [ERC-4337](./eip-4337.md) bundler, the logs must only include those relevant to the user operation constructed using the calls submitted via `wallet_sendCalls`. I.e. the logs should not include those from other unrelated user operations submitted in the same bundle.
+- The receipts in the `receipts` field MUST be in order they are included on-chain.
+- The `receipts` field MUST contain receipts for all calls in a batch that were included on-chain, including reverted ones.
+- If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsStatus` MUST return a single receipt, corresponding to the transaction in which the calls were included.
+- The `logs` in the receipt objects MUST only include logs relevant to the calls submitted using `wallet_sendCalls`. For example, in the case of a transaction submitted onchain by an [ERC-4337](./eip-4337.md) bundler, the logs must only include those relevant to the user operation constructed using the calls submitted via `wallet_sendCalls`. I.e. the logs should not include those from other unrelated user operations submitted in the same bundle.
 
 #### `wallet_getCallsStatus` RPC Specification
 
@@ -160,13 +163,13 @@ type GetCallsResult = {
 The purpose of the `batchStatus` field is to provide a short summary of the current status of the batch.
 It provides some off-chain context to the array of inner transaction `receipts`.
 
-| Name      | Description                                                                                                          |
-|-----------|----------------------------------------------------------------------------------------------------------------------|
-| PENDING   | Batch has been received by the wallet but has not completed execution on-chain                                       |
-| SUCCESS   | Batch has been included on-chain without reverts, receipts array contains info of all calls                          |
-| PARTIAL   | Batch has been included on-chain only partially, the rest is either reverted or invalid. Receipts array contains info of all on-chain included calls             |
-| FAILURE   | Batch has been invalid or reverted completely and only changes related to gas charge may have been included on-chain |
-| DISCARDED | Batch has not been included on-chain and wallet will not retry                                                       |
+| Name      | Description                                                                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PENDING   | Batch has been received by the wallet but has not completed execution on-chain                                                                       |
+| SUCCESS   | Batch has been included on-chain without reverts, receipts array contains info of all calls                                                          |
+| PARTIAL   | Batch has been included on-chain only partially, the rest is either reverted or invalid. Receipts array contains info of all on-chain included calls |
+| FAILURE   | Batch has been invalid or reverted completely and only changes related to gas charge may have been included on-chain                                 |
+| DISCARDED | Batch has not been included on-chain and wallet will not retry                                                                                       |
 
 ##### `wallet_getCallsStatus` Example Parameters
 
@@ -221,9 +224,7 @@ type ShowCallsParams = string; // Call bundle identifier returned by wallet_send
 This method accepts a call bundle identifier returned by a `wallet_sendCalls` call.
 
 ```json
-[
-  "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
-]
+["0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"]
 ```
 
 ### `wallet_getCapabilities`
@@ -305,7 +306,7 @@ For each chain on which a wallet can submit multiple calls atomically, the walle
   "0x2105": {
     "atomicBatch": {
       "supported": true
-    },
+    }
   },
   "0x14A34": {
     "atomicBatch": {

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -50,14 +50,16 @@ The wallet:
 - MUST send the calls in the order specified in the request
 - MUST send the calls on the same chain identified by the request's `chainId` property
 - MUST NOT await for any calls to be finalized to complete the batch
+- MUST submit multiple calls as part of a single transaction, unless instructions for sequential execution are provided via a `capability`.
+  - Note that such a `capability` is not in the scope of this EIP and should be defined in its own ERC.
 - MUST NOT send any calls from the request if the user rejects the request
 - MAY revert all calls if any call fails
 - MAY send all calls as part of one or more transactions, depending on wallet capability
 - SHOULD stop executing the calls if any call fails
 - MAY reject the request if the from address does not match the enabled account
 - MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
-- MUST reject the request if it contains a `capability` that is not supported by the wallet and the `capability` is not explicitly marked as optional.
-  - Capabilities MUST be marked as optional by applications sending requests to wallets by passing an `optional` parameter set to `true` for each `capability` that is not required.
+- MUST reject the request if it contains a `capability` (either top-level or call-level) that is not supported by the wallet and the `capability` is not explicitly marked as optional.
+  - Capabilities (both top-level and call-level) MUST be marked as optional by applications sending requests to wallets by passing an `optional` parameter set to `true` for each `capability` that is not required.
 
 #### `wallet_sendCalls` RPC Specification
 
@@ -283,9 +285,7 @@ The capabilities below are for illustrative purposes.
 
 Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
 
-This capability is expressed separately on each chain and should be interpreted as a guarantee only for batches of transactions on that chain; batches including calls to multiple chains is out of scope of this capability and this specification.
-
-If a wallet has affirmatively expressed this `atomicBatch` capability to a calling application, it MUST submit calls submitted with `wallet_sendCalls` as part of a single transaction.
+Note that this capability is purely declarative. I.e. this capability is not meant to be paired with a `wallet_sendCalls` request (at either top-level nor call-level), as this EIP specifies that multiple calls MUST, by default, be executed as part of a single transaction.
 
 #### `atomicBatch` Capability Specification
 


### PR DESCRIPTION
- Update the spec to specify that by default multiple calls MUST be executed atomically.
- Add clarification around required behavior for unsupported capabilities.
- Update `atomicBatch` description accordingly.
