### PR TITLE
Make wallet_sendCalls "from" optional

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -51,6 +51,7 @@ The wallet:
 * MUST send the calls in the order specified in the request
 * MUST send the calls on the same chain identified by the request's `chainId` property
 * MUST send the calls from the address specified in the request's `from` property, if provided
+  * If `from` is not provided the wallet SHOULD present the user with an opportunity to view and change the `from` address during confirmation
 * MUST NOT await for any calls to be finalized to complete the batch
 * MUST submit multiple calls as an atomic unit in a single transaction
 * MUST NOT send any calls from the request if the user rejects the request

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -50,6 +50,7 @@ The wallet:
 
 * MUST send the calls in the order specified in the request
 * MUST send the calls on the same chain identified by the request's `chainId` property
+* MUST send the calls from the address specified in the request's `from` property, if provided
 * MUST NOT await for any calls to be finalized to complete the batch
 * MUST submit multiple calls as an atomic unit in a single transaction
 * MUST NOT send any calls from the request if the user rejects the request
@@ -170,19 +171,19 @@ type GetCallsResult = {
 The purpose of the `status` field is to provide a short summary of the current status of the batch.
 It provides some off-chain context to the array of inner transaction `receipts`.
 
-| Code | Description |
-|------|-------------|
-| 100  | Batch has been received by the wallet but has not completed execution onchain (pending) |
-| 200  | Batch has been included onchain without reverts, receipts array contains info of all calls (confirmed) |
-| 400  | Batch has not been included onchain and wallet will not retry (offchain failure) |
-| 500  | Batch reverted completely and only changes related to gas charge may have been included onchain (chain rules failure) |
-
 Status codes follow these categories:
 
 * 1xx: Pending states
 * 2xx: Confirmed states
 * 4xx: Offchain failures
 * 5xx: Chain rules failures
+
+| Code | Description |
+|------|-------------|
+| 100  | Batch has been received by the wallet but has not completed execution onchain (pending) |
+| 200  | Batch has been included onchain without reverts, receipts array contains info of all calls (confirmed) |
+| 400  | Batch has not been included onchain and wallet will not retry (offchain failure) |
+| 500  | Batch reverted completely and only changes related to gas charge may have been included onchain (chain rules failure) |
 
 More specific status codes within these categories should be proposed and agreed upon in separate ERCs.
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -65,8 +65,8 @@ The wallet:
 ```typescript
 type SendCallsParams = {
   version: string;
-  from: `0x${string}`;
-  chainId: `0x${string}` | undefined; // Hex chain id
+  from?: `0x${string}` | undefined;
+  chainId: `0x${string}`; // Hex chain id
   calls: {
     to?: `0x${string}` | undefined;
     data?: `0x${string}` | undefined;
@@ -147,7 +147,7 @@ type GetCallsParams = string;
 
 type GetCallsResult = {
   id: `0x${string}`;
-  chainId?: `0x${string}`;
+  chainId: `0x${string}`;
   status: number; // See "Status Codes"
   receipts?: {
     logs: {


### PR DESCRIPTION
- makes the `from` param in `wallet_sendCalls` optional
  - this lets apps send requests to wallets without specifying an address if it is not needed. this could be used, for example, to allow for simple P2P payments without needing to first "connect" to an app.
  - this also follows, for example, ERC-7715, which has an optional `address` parameter.