### PR TITLE
Specify `unauthorized` error re `getCapabilities` requests

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -9,6 +9,7 @@ last-call-deadline: 2024-09-05
 type: Standards Track
 category: Interface
 created: 2022-10-17
+requires: 1193
 ---
 
 ## Abstract
@@ -248,7 +249,7 @@ This method accepts a call bundle identifier returned by a `wallet_sendCalls` ca
 
 This RPC allows an application to request capabilities from a wallet (e.g. batch transactions, paymaster communication), without distinct discovery and permission requests. For more on the difference between requesting capabilities and discovering features, see the ["Privacy Considerations" section](#privacy-considerations).
 
-This method SHOULD return an error if the user has not already authorized a connection between the application and the requested address.
+This method SHOULD return a `4100 unauthorized` error if the user has not already authorized a connection between the application and the requested address, as specified in [EIP-1193](./eip-1193.md).
 
 We expect the community to align on the definition of additional capabilities in separate ERCs over time.
 


### PR DESCRIPTION
- specifies that the response to `getCapabilities` should be a `4100 unauthorized` error as specified in EIP-1193