### PR TITLE
Specify 0x prefixed chain id

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -33,7 +33,7 @@ Apps may begin using these first three methods immediately, falling back to `eth
 
 ### `wallet_sendCalls`
 
-Requests that a wallet submits a batch of calls. `from` and `chainId` are identified by [EIP-155](./eip-155.md) integers expressed in hexadecimal notation.
+Requests that a wallet submits a batch of calls. `from` and `chainId` are identified by [EIP-155](./eip-155.md) integers expressed in hexadecimal notation with a `0x` prefix.
 The items in the `calls` field are simple `{to, data, value}` tuples.
 
 The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an [ERC-4337](./eip-4337.md) wallet can request a `paymasterAndData` input for a user operation.


### PR DESCRIPTION
- specify that chain ids in hex should be `0x`-prefixed