### PR TITLE
Add optional id

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -91,7 +91,7 @@ type SendCallsParams = {
 
 type SendCallsResult = {
   id: string;
-  capabilities?: Record<string, Capability>;
+  capabilities?: Record<string, any>;
 };
 ```
 
@@ -177,7 +177,7 @@ type GetCallsResult = {
     gasUsed: `0x${string}`;
     transactionHash: `0x${string}`;
   }[];
-  capabilities?: Record<string, Capability>;
+  capabilities?: Record<string, any>;
 };
 ```
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -63,7 +63,7 @@ The wallet:
 * MUST reject the request if it contains a `capability` (either top-level or call-level) that is not supported by the wallet and the `capability` is not explicitly marked as optional.
   * Applications may mark a capability as optional by setting `optional` to `true`. See the RPC Specification section below for details.
 * If provided, the wallet MUST respect the `id` field and return it in the response.
-  * App-provided `id`s MUST be unique per sender per app.
+  * App-provided `id`s MUST be unique per sender per app, where each "app" SHOULD be identified by their domain.
   * Wallets MUST reject requests with duplicate `id`s.
 
 
@@ -77,21 +77,21 @@ type Capability = {
 
 type SendCallsParams = {
   version: string;
-  id?: string | undefined;
-  from?: `0x${string}` | undefined;
+  id?: string;
+  from?: `0x${string}`;
   chainId: `0x${string}`; // Hex chain id
   calls: {
-    to?: `0x${string}` | undefined;
-    data?: `0x${string}` | undefined;
-    value?: `0x${string}` | undefined; // Hex value
-    capabilities?: Record<string, Capability> | undefined;
+    to?: `0x${string}`;
+    data?: `0x${string}`;
+    value?: `0x${string}`; // Hex value
+    capabilities?: Record<string, Capability>;
   }[];
-  capabilities?: Record<string, Capability> | undefined;
+  capabilities?: Record<string, Capability>;
 };
 
 type SendCallsResult = {
   id: string;
-  capabilities?: Record<string, Capability> | undefined;
+  capabilities?: Record<string, Capability>;
 };
 ```
 
@@ -131,7 +131,7 @@ Note that since the `paymasterService` `capability` is marked as optional, walle
 
 If the `id` field was provided by the app, the wallet MUST return the same value in the response.
 
-Otherwise, the identifier MUST be a unique string up to 4096 bytes (8194 characters including leading `0x`).
+The identifier MUST be a unique string up to 4096 bytes (8194 characters including leading `0x`).
 
 Within 24 hours from the corresponding `wallet_sendCalls`, wallets SHOULD return a call-batch status when `wallet_getCallsStatus` is called with this value.
 
@@ -177,7 +177,7 @@ type GetCallsResult = {
     gasUsed: `0x${string}`;
     transactionHash: `0x${string}`;
   }[];
-  capabilities?: Record<string, Capability> | undefined;
+  capabilities?: Record<string, Capability>;
 };
 ```
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -62,6 +62,10 @@ The wallet:
 * MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
 * MUST reject the request if it contains a `capability` (either top-level or call-level) that is not supported by the wallet and the `capability` is not explicitly marked as optional.
   * Applications may mark a capability as optional by setting `optional` to `true`. See the RPC Specification section below for details.
+* If provided, the wallet MUST respect the `id` field and return it in the response.
+  * App-provided `id`s MUST be unique per sender per app.
+  * Wallets MUST reject requests with duplicate `id`s.
+
 
 #### `wallet_sendCalls` RPC Specification
 
@@ -73,6 +77,7 @@ type Capability = {
 
 type SendCallsParams = {
   version: string;
+  id?: string | undefined;
   from?: `0x${string}` | undefined;
   chainId: `0x${string}`; // Hex chain id
   calls: {
@@ -124,7 +129,10 @@ Note that since the `paymasterService` `capability` is marked as optional, walle
 
 ##### `wallet_sendCalls` Example Return Value
 
-The identifier MUST be unique 64 bytes represented as a hex encoded string.
+If the `id` field was provided by the app, the wallet MUST return the same value in the response.
+
+Otherwise, the identifier MUST be a unique string up to 4096 bytes (8194 characters including leading `0x`).
+
 Within 24 hours from the corresponding `wallet_sendCalls`, wallets SHOULD return a call-batch status when `wallet_getCallsStatus` is called with this value.
 
 The `capabilities` object allows the wallets to attach a capability-specific metadata to the response.


### PR DESCRIPTION
- adds optional `id` to wallet_sendCalls parameters
- updates capability response interface (response interface should be any, ie not the same as the capability request interface)